### PR TITLE
增加 / 更正 o1 相关模型的映射

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -15,6 +15,8 @@ const port = process.env.PORT || 8080;
 const validApiKey = process.env.PASSWORD;
 const availableModels = [
     "openai_o1",
+    "openai_o1_mini",
+    "openai_o1_preview",
     "gpt_4o",
     "gpt_4_turbo",
     "gpt_4",
@@ -46,8 +48,9 @@ const modelMappping = {
     "gpt-4": "gpt_4",
     "gpt-4o": "gpt_4o",
     "gpt-4-turbo": "gpt_4_turbo",
-    "openai-o1": "openai_o1",
-    "o1-preview": "openai_o1",
+    "o1": "openai_o1",
+    "o1-preview": "openai_o1_preview",
+    "o1-mini": "openai_o1_mini"
 };
 
 // import config.mjs


### PR DESCRIPTION
修改如下：

* OpenAI 官方的 o1（正式版）模型名称不是 `openai-o1` 而是 `o1`
* 将 `o1_preview` 映射到 `openai_o1_preview`（而不是直接映射到 `openai_o1`），因为本质上 `o1` 和 `o1-preview` 是两个模型，YOU 上也有一一对应
* 增加 `o1-mini` 及其对应映射